### PR TITLE
Support manual so path settings from environment variables

### DIFF
--- a/lib/upl/extern.rb
+++ b/lib/upl/extern.rb
@@ -27,6 +27,7 @@ module Upl
     #   /usr/lib64/swipl-7.7.18/lib/x86_64-linux/libswipl.so
     # which should actually exist
     def self.so_path
+      return ENV['SWIPL_SO_PATH'] unless ENV['SWIPL_SO_PATH'].nil?
       values = swipl_config_values
       p = Pathname "#{values['PLBASE']}/lib/#{values['PLARCH']}/#{values['PLLIB'].gsub('-l', 'lib')}.#{values['PLSOEXT']}"
       p.realpath.to_s


### PR DESCRIPTION
Support manual so path settings from environment variables.

The given so path may not exist in cases like on arm64 macos. By providing a environment variable that could manually set the so path may be easier.